### PR TITLE
Fix `Dict` type of loading YAML files to be `Dict{String,Any}`

### DIFF
--- a/src/fileops.jl
+++ b/src/fileops.jl
@@ -66,7 +66,7 @@ function _load(path, ::DataFormat{:TOML})
 end
 function _load(path, ::DataFormat{:YAML})
     open(path, "r") do io
-        YAML.load(io)
+        YAML.load(io; dicttype = Dict{String,Any})  # To keep up with JSON & TOML results
     end
 end
 


### PR DESCRIPTION
to keep up with JSON & TOML results