### PR TITLE
fix `load`ing YAML: Save YAML to JSON, then parse JSON

### DIFF
--- a/src/fileops.jl
+++ b/src/fileops.jl
@@ -67,7 +67,7 @@ end
 function _load(path, ::DataFormat{:YAML})
     open(path, "r") do io
         dict = YAML.load(io)
-        return Dict(string(key) => value for (key, value) in dict)  # To keep up with JSON & TOML results
+        return JSON.parse(JSON.json(dict))  # To keep up with JSON & TOML results
     end
 end
 


### PR DESCRIPTION
The [old ways](https://github.com/MineralsCloud/AbInitioSoftwareBase.jl/blob/76ec786a1215a9ffed47cd6346caea20bd8c7125/src/fileops.jl#L70) does not work for nested `Dicts`:
```julia
julia> load("eos.yaml")
Dict{String, Any} with 6 entries:
  "template"  => "template.in"
  "fixed"     => Dict{Any, Any}("pressures"=>Dict{Any, Any}("values"=>[-5, -2, 0, 5, 10, 15, 17, 20], "unit"=>"GPa"))
  "save"      => Dict{Any, Any}("status"=>"status.jls")
  "trial_eos" => Dict{Any, Any}("values"=>Any["300.44 bohr^3", "74.88 GPa", 4.82], "type"=>"bm3")
  "recipe"    => "eos"
  "cli"       => Dict{Any, Any}("mpi"=>Dict{Any, Any}("np"=>16))
```
i.e., we will still have `Dict{Any, Any}` in its values. This does not please `Configurations.jl`. So a better way is to save to JSON first, then parse JSON.